### PR TITLE
let's do even the bad things in the proper way

### DIFF
--- a/PygmentsKitTool/Base.lproj/Main.storyboard
+++ b/PygmentsKitTool/Base.lproj/Main.storyboard
@@ -1,8 +1,9 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="11198.2" systemVersion="16A294a" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="15G1217" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11198.2"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11762"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--Application-->
@@ -696,7 +697,7 @@
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <size key="minSize" width="478" height="268"/>
-                                            <size key="maxSize" width="478" height="10000000"/>
+                                            <size key="maxSize" width="480" height="10000000"/>
                                             <color key="insertionPointColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                         </textView>
                                     </subviews>

--- a/PygmentsKitTool/ViewController.swift
+++ b/PygmentsKitTool/ViewController.swift
@@ -25,7 +25,7 @@ import PygmentsKit
 
 class ViewController: NSViewController {
 
-    @IBOutlet weak var textView: NSTextView!
+    @IBOutlet var textView: NSTextView!
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -42,6 +42,8 @@ class ViewController: NSViewController {
         
         try! AttributedParser.parse(textView.textStorage!.string, with: "swift", theme: theme) { (range, _, attributes) in
             self.textView.textStorage!.addAttributes(attributes, range: range)
+            
+            return true
         }
     }
 


### PR DESCRIPTION
- allow to interrupt parsers from callback closures
- optimized parsing of script output in tokenize method
- no weak for NSTextView (OS X 10.11 is sick)
- some more code reading & optimization